### PR TITLE
set poll mode if Accept header is not set

### DIFF
--- a/src/bullet_handler.erl
+++ b/src/bullet_handler.erl
@@ -182,6 +182,8 @@ get_mode([{{<<"text">>, <<"event-stream">>, _}, _, _}|_], Req) ->
 get_mode([_|Accepts], Req) ->
 	get_mode(Accepts, Req);
 get_mode([], Req) ->
+	{poll, Req};
+get_mode(undefined, Req) ->
 	{poll, Req}.
 
 start_get_mode(poll, Req) ->


### PR DESCRIPTION
assume \*/\* from http://tools.ietf.org/html/rfc7231#section-5.3.2

"A request without any Accept header field implies that the user agent
will accept any media type in response"

to easily test follow the steps from http://efene.org/guides/cowboy-websockets-server-sent-events-comet-json.html (an incomplete guide I created to reproduce this issue)

and after starting run:

    curl http://localhost:8080/listen

this should block waiting for a response, cancel with ctrl+c and now run:

    curl -H "Accept:" http://localhost:8080/listen

this will remove the Accept header from the request (by default \*/\* on curl), it will fail with something like:

	=ERROR REPORT==== 13-May-2015::11:23:59 ===
	Error in process <0.253.0> with exit value:
	{[{reason,function_clause},{mfa,{bullet_handler,init,3}},{stacktrace,[{bullet_handler,get_mode,[undefined,{http_req,#Port<0.43879>,ranch_tcp,keepalive,<0.253.0>,<<3
	bytes>>,'HTTP/1.1',{{127,0,0,1},34618},<<9 bytes>>,undefined,8080,<<7
	bytes>>,undefined,<<0 bytes>>,undefined,[],[{<<10 bytes>>,<<11
	bytes>>},{<<4 bytes>>,<<14 bytes>>}],[{<<6 bytes>>,undefined... 


	=ERROR REPORT==== 13-May-2015::11:23:59 ===
	Ranch listener http had connection process started with
	cowboy_protocol:start_link/4 at <0.253.0> exit with reason:
	{[{reason,function_clause},{mfa,{bullet_handler,init,3}},{stacktrace,[{bullet_handler,get_mode,[undefined,{http_req,#Port<0.43879>,ranch_tcp,keepalive,<0.253.0>,<<"GET">>,'HTTP/1.1',{{127,0,0,1},34618},<<"localhost">>,undefined,8080,<<"/listen">>,undefined,<<>>,undefined,[],[{<<"user-agent">>,<<"curl/7.37.0">>},{<<"host">>,<<"localhost:8080">>}],[{<<"accept">>,undefined}],undefined,[],waiting,<<>>,undefined,false,waiting,[],<<>>,undefined}],[{file,"/home/mariano/tmp/mypush/_build/default/lib/bullet/src/bullet_handler.erl"},{line,180}]},{bullet_handler,init,4,[{file,"/home/mariano/tmp/mypush/_build/default/lib/bullet/src/bullet_handler.erl"},{line,57}]},{cowboy_handler,handler_init,4,[{file,"/home/mariano/tmp/mypush/_build/default/lib/cowboy/src/cowboy_handler.erl"},{line,64}]},{cowboy_protocol,execute,4,[{file,"/home/mariano/tmp/mypush/_build/default/lib/cowboy/src/cowboy_protocol.erl"},{line,442}]}]},{req,[{socket,#Port<0.43879>},{transport,ranch_tcp},{connection,keepalive},{pid,<0.253.0>},{method,<<"GET">>},{version,'HTTP/1.1'},{peer,{{127,0,0,1},34618}},{host,<<"localhost">>},{host_info,undefined},{port,8080},{path,<<"/listen">>},{path_info,undefined},{qs,<<>>},{qs_vals,undefined},{bindings,[]},{headers,[{<<"user-agent">>,<<"curl/7.37.0">>},{<<"host">>,<<"localhost:8080">>}]},{p_headers,[]},{cookies,undefined},{meta,[]},{body_state,waiting},{buffer,<<>>},{multipart,undefined},{resp_compress,false},{resp_state,waiting},{resp_headers,[]},{resp_body,<<>>},{onresponse,undefined}]},{opts,[{handler,mypush_listen_handler}]}],[{cowboy_protocol,execute,4,[{file,"/home/mariano/tmp/mypush/_build/default/lib/cowboy/src/cowboy_protocol.erl"},{line,442}]}]}

after applying the patch both should work the same way